### PR TITLE
Rename Auv3Buffer to AUv3Buffer

### DIFF
--- a/src/gen_dsp/templates/auv3/auv3_buffer.h
+++ b/src/gen_dsp/templates/auv3/auv3_buffer.h
@@ -4,11 +4,11 @@
 
 #include "genlib.h"
 
-struct Auv3Buffer : public DataInterface<t_sample> {
-    Auv3Buffer() : DataInterface<t_sample>() {
+struct AUv3Buffer : public DataInterface<t_sample> {
+    AUv3Buffer() : DataInterface<t_sample>() {
         mData = nullptr; mOwnedData = nullptr; dim = 0; channels = 1;
     }
-    ~Auv3Buffer() { if (mOwnedData) { delete[] mOwnedData; mOwnedData = nullptr; } }
+    ~AUv3Buffer() { if (mOwnedData) { delete[] mOwnedData; mOwnedData = nullptr; } }
 
     void allocate(long frames, long numChannels) {
         if (mOwnedData) delete[] mOwnedData;


### PR DESCRIPTION
The AUv3 naming seems to be more commonly used in the project, and this change fixes errors by which _ext_auv3.cpp attempts to refer to the AUv3Buffer struct.